### PR TITLE
chore: set user/password env in publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,3 +19,6 @@ jobs:
       run: ./gradlew test
     - name: Publish build
       run: ./gradlew publish
+      env:
+        USERNAME: ${{ BINTRAY_USER }}
+        PASSWORD: ${{ BINTRAY_API_KEY }}


### PR DESCRIPTION
Set environment variables `USERNAME`, `PASSWORD` for publish action.

The publish action is setting for publish to [Bintray](https://bintray.com/bintray/jcenter), and such `BINTRAY_USER`, `BINTRAY_API_KEY` are defined in secrets. 